### PR TITLE
Change strategy on service_supervisor from all_for_one to rest_for_one

### DIFF
--- a/examples/auth.exs
+++ b/examples/auth.exs
@@ -1,21 +1,27 @@
 defmodule Example.Auth do
+  @moduledoc false
   def start do
-    config = "CLAIM"
-    |> ZssService.get_instance config
-    |> ZssService.add_verb("verify", {Examples.SampleHandler, :verify})
+    config = %{sid: "CLAIM"}
+    |> ZssService.get_instance
+    |> ZssService.add_verb({"verify", Examples.SampleHandler, :verify})
 
-    ZssService.Service.run config
+    0..3
+    |> Enum.each(fn _ ->
+      ZssService.run config
+    end)
 
     loop
   end
 
-  def loop() do #Keep the script running
+  def loop do #Keep the script running
     loop()
   end
 end
 
 defmodule Examples.SampleHandler do
+  @moduledoc false
   defmodule VerifyPayload do
+    @moduledoc false
     defstruct [
       permissions: [],
       resourceId: nil,
@@ -45,7 +51,8 @@ defmodule Examples.SampleHandler do
   }
 
   def verify(payload, message) do
-    result = VerifyPayload.new(payload)
+    result = payload
+    |> VerifyPayload.new
     |> verify_access
     |> case do
       {:ok, result} -> {:ok, {result, message}}
@@ -71,4 +78,4 @@ defmodule Examples.SampleHandler do
 end
 
 
-Example.Pong.start
+Example.Auth.start

--- a/examples/pong.exs
+++ b/examples/pong.exs
@@ -1,4 +1,6 @@
 defmodule Example.Pong do
+  @moduledoc false
+
   def start do
     config = %{sid: "PING_ME"}
     |> ZssService.get_instance
@@ -6,8 +8,10 @@ defmodule Example.Pong do
     |> ZssService.add_verb({"list", Examples.SampleHandler, :ping_me_more})
 
     {:ok, pid} = ZssService.run config
+    {:ok, pid} = ZssService.run config
+    {:ok, pid} = ZssService.run config
 
-    loop
+    loop()
   end
 
   def loop do #Keep the script running
@@ -16,6 +20,8 @@ defmodule Example.Pong do
 end
 
 defmodule Examples.SampleHandler do
+  @moduledoc false
+
   def ping_me(_payload, message) do
     {:ok, {
       %{ping: "PONG"},

--- a/lib/zss_service/service_supervisor.ex
+++ b/lib/zss_service/service_supervisor.ex
@@ -20,7 +20,7 @@ defmodule ZssService.ServiceSupervisor do
       worker(ZssService.Service, [config])
     ]
 
-    opts = [strategy: :one_for_all]
+    opts = [strategy: :rest_for_one]
     Logger.debug(fn -> "Service supervisor started with #{inspect self}" end)
     supervise(children, opts)
   end


### PR DESCRIPTION
The implication is that heartbeat crashes will not stop the worker, but make a new heartbeat and has no effect on the actual worker!